### PR TITLE
Add tare feature

### DIFF
--- a/modules/app.xql
+++ b/modules/app.xql
@@ -310,7 +310,7 @@ function app:query-stats($node as node(), $model as map(*), $sort as xs:string) 
         for $query in subsequence($queries, 1, 20)
         return
             <tr>
-                <td>{app:truncate-source(replace($query/@source, "^.*/([^/]+)$", "$1"))}</td>
+                <td>{app:truncate-source($query/@source)}</td>
                 <td class="trace-calls">{$query/@calls/string()}</td>
                 <td class="trace-elapsed">{$query/@elapsed/string()}</td>
             </tr>
@@ -334,7 +334,7 @@ function app:function-stats($node as node(), $model as map(*), $sort as xs:strin
         return
             <tr>
                 <td>{$func/@name/string()}</td>
-                <td>{app:truncate-source(replace($func/@source, "^.*/([^/]+)$", "$1"))}</td>
+                <td>{app:truncate-source($func/@source)}</td>
                 <td class="trace-calls">{$func/@calls/string()}</td>
                 <td class="trace-elapsed">{$func/@elapsed/string()}</td>
             </tr>
@@ -358,7 +358,7 @@ function app:index-stats($node as node(), $model as map(*), $sort as xs:string) 
         let $optimization := $app:OPTIMIZATIONS/opt[@n = $index/@optimization]/string()
         return
             <tr>
-                <td>{app:truncate-source(replace($index/@source, "^.*/([^/]+)$", "$1"))}</td>
+                <td>{app:truncate-source($index/@source)}</td>
                 <td class="trace-calls">{$index/@type/string()}</td>
                 <td class="trace-calls">
                 {

--- a/modules/app.xql
+++ b/modules/app.xql
@@ -9,7 +9,7 @@ declare namespace output="http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace json="http://www.json.org";
 
 
-import module namespace console="http://exist-db.org/xquery/console" at "java:org.exist.console.xquery.ConsoleModule";
+(: import module namespace console="http://exist-db.org/xquery/console" at "java:org.exist.console.xquery.ConsoleModule"; :)
 import module namespace scheduler="http://exist-db.org/xquery/scheduler" at "java:org.exist.xquery.modules.scheduler.SchedulerModule";
 import module namespace templates="http://exist-db.org/xquery/templates" ;
 import module namespace config="http://exist-db.org/apps/admin/config" at "config.xqm";
@@ -209,8 +209,8 @@ function app:profile($node as node(), $model as map(*), $action as xs:string?) {
             map {
                 "trace" := $adjusted-trace
             }
-            ,
-            if (exists($tare)) then console:log(<log><raw-trace>{$trace}</raw-trace><adjusted>{$adjusted-trace}</adjusted><tare>{$tare}</tare></log>) else ()
+            (:,
+            if (exists($tare)) then console:log(<log><raw-trace>{$trace}</raw-trace><adjusted>{$adjusted-trace}</adjusted><tare>{$tare}</tare></log>) else () :)
         )
 };
 

--- a/modules/app.xql
+++ b/modules/app.xql
@@ -406,9 +406,13 @@ declare %private function app:sort($function as element(), $sort as xs:string) {
         xs:double($function/@elapsed)
 };
 
-declare %private function app:truncate-source($source as xs:string) as xs:string {
+declare %private function app:truncate-source($source as xs:string) {
     if (string-length($source) gt 60) then
-        substring($source, 1, 60)
+        let $analyze := analyze-string($source, "^(.*/)([^/]+)$")
+        let $path := $analyze//fn:group[1]
+        let $filename := $analyze//fn:group[2]
+        return
+            <span title="{$source}">{substring($path, 1, 60 - string-length($filename)) || '[...]' || $filename}</span>
     else
         $source
 };

--- a/profiling.html
+++ b/profiling.html
@@ -28,6 +28,8 @@
                             <span class="glyphicon glyphicon-off"/> Enable Tracing</a>
                         <a href="?action=clear" class="btn btn-default">
                             <span class="glyphicon glyphicon-remove"/> Clear</a>
+                        <a href="?action=tare" class="btn btn-default" data-template="app:btn-tare">
+                            <span class="glyphicon glyphicon-record"/> Tare</a>
                         <a href="?action=refresh" class="btn btn-default">
                             <span class="glyphicon glyphicon-refresh"/> Refresh</a>
                     </div>


### PR DESCRIPTION
- press the "Tare" button to establish a baseline from which to report subsequent results
- the idea is to eliminate monex's own results from subsequent refreshes and help users focus on relevant results
- uses actual statistics as baseline, plus some hard-coded ones to eliminate the "tare" functions themselves
- press the "Clear Tare" button to return to normal behavior

![Screenshot showing "Clear Tare"](http://i.stack.imgur.com/zmqPN.png)

This is functionally complete, but I would really like comments, and I may need to add some documentation to explain the feature.