### PR TITLE
Align version in GitHub repo with source in public-repo, prepare version bump

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,7 +1,7 @@
 exist.dir=../../eXist/hsg
 
 project.name=monex
-project.version=0.9.5
+project.version=0.9.7
 
 ivy.version=2.4.0
 ivy_url=http://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.version}/ivy-${ivy.version}.jar

--- a/build.xml
+++ b/build.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project default="xar" name="monex">
-	<property file="build.properties"/>
-    <property name="project.version" value="0.1"/>
-    <property name="project.app" value="monex"/>
+    <property file="build.properties"/>
     <property name="build.dir" value="build"/>
     <property name="java.src" value="src"/>
     <property name="java.classes" value="${build.dir}/classes"/>

--- a/exist.xml
+++ b/exist.xml
@@ -4,7 +4,7 @@
         <namespace>http://exist-db.org/xquery/console</namespace>
         <class>org.exist.console.xquery.ConsoleModule</class>
     </java>
-    <jar>exist-monex-0.9.5.jar</jar>
+    <jar>exist-monex-0.9.7.jar</jar>
     <jar>jetty-util-ajax-9.3.9.v20160517.jar</jar>
     <jar>websocket-common-9.3.9.v20160517.jar</jar>
     <jar>websocket-servlet-9.3.9.v20160517.jar</jar>

--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/monex" abbrev="monex" version="0.9.5"
+<package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/monex" abbrev="monex" version="0.9.7"
          spec="1.0">
     <title>Monitoring and Profiling for eXist</title>
     <dependency package="http://exist-db.org/apps/shared"/>

--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://expath.org/ns/pkg" name="http://exist-db.org/apps/monex" abbrev="monex" version="0.9.7"
          spec="1.0">
-    <title>Monitoring and Profiling for eXist</title>
+    <title>Monitoring and Profiling for eXist (Monex)</title>
     <dependency package="http://exist-db.org/apps/shared"/>
     <dependency processor="http://exist-db.org" semver-min="3.0.2" semver-max="3.1.0"/>
 </package>

--- a/modules/job.xql
+++ b/modules/job.xql
@@ -216,6 +216,15 @@ declare function job:alerts($instance as element(instance), $jmx as element(jmx:
             ()
 };
 
+(: declare function job:tests($instance as element(instance)) {
+    for $test in $instance/test
+    let $request := 
+        <http:request method="GET" href="{$test/@url}" timeout="30"/>
+    
+}; :)
+
+
+
 if ($local:operation and $local:operation != "") then
     console:send($job:CHANNEL, job:response("pending", (), ()))
 else

--- a/repo.xml
+++ b/repo.xml
@@ -4,7 +4,7 @@
     <author>Wolfgang Meier</author>
     <author>Joe Wicentowski</author>
     <author>Lars Windauer</author>
-    <website/>
+    <website>https://github.com/wolfgangmm/monex</website>
     <status>alpha</status>
     <license>GNU-LGPL</license>
     <copyright>true</copyright>
@@ -35,6 +35,16 @@
             <ul xmlns="http://www.w3.org/1999/xhtml">
                 <li>Update console logging to match changes in internal eXist API</li>
                 <li>Add hipchat notifications</li>
+            </ul>
+        </change>
+        <change version="0.9.6">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>New "Tare" button in Query Profiling pane factors out external processes from results</li>
+            </ul>
+        </change>
+        <change version="0.9.7">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>Sync source with GitHub repository</li>
             </ul>
         </change>
     </changelog>


### PR DESCRIPTION
The version in the public-repo (0.9.6) had changes that were not in the GitHub repo (still at 0.9.5). This PR updates the source in GitHub to the latest changes in public-repo (as discussed with @dizzzz in https://github.com/eXist-db/dashboard/pull/48#issuecomment-275946336), updates the release notes, and prepares a new release (0.9.7) to get users on the version built directly from source control.