### PR TITLE
Bump to v0.9.8

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -4,7 +4,7 @@
 #
 
 project.name=monex
-project.version=0.9.7
+project.version=0.9.8
 
 # Path to $EXIST_HOME
 exist.dir=../../eXist/hsg

--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -3,5 +3,5 @@
          spec="1.0">
     <title>Monitoring and Profiling for eXist (Monex)</title>
     <dependency package="http://exist-db.org/apps/shared"/>
-    <dependency processor="http://exist-db.org" semver-min="3.0.2" semver-max="3.2.0"/>
+    <dependency processor="http://exist-db.org" semver-min="3.0.2"/>
 </package>

--- a/repo.xml
+++ b/repo.xml
@@ -47,5 +47,11 @@
                 <li>Sync source with GitHub repository</li>
             </ul>
         </change>
+        <change version="0.9.8">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>Show version of Java in the Monitoring > System Information pane</li>
+                <li>Removed package's semver-max to ensure compatibility with all eXist 3.x releases</li>
+            </ul>
+        </change>
     </changelog>
 </meta>


### PR DESCRIPTION
Removed package's `dependency/@semver-max` to ensure compatibility with 3.2.0 release and all future eXist 3.x releases